### PR TITLE
Modal confirm

### DIFF
--- a/src/components/ModalComp.vue
+++ b/src/components/ModalComp.vue
@@ -38,6 +38,8 @@
         :text="modalText"
         :width="modalWidth"
         :minWidth="modalMinWidth"
+        @confirm="$emit('confirm')"
+        :confirm-button-text="confirmButtonText"
       ></ModalConfirmation>
     </div>
   </div>
@@ -105,5 +107,8 @@ export default class ModalComp extends Vue {
   notes!: string;
 
   modalNotes: string = this.notes;
+
+  @Prop({ default: 'Confirm' })
+  confirmButtonText!: string;
 }
 </script>

--- a/src/components/ModalConfirmation.vue
+++ b/src/components/ModalConfirmation.vue
@@ -18,7 +18,7 @@
             :size="'fixed-width'"
             @click="$modal.hide('modal-confirmation')"
           ></Button>
-          <Button :variation="'warning'" :title="'Delete'" :size="'fixed-width'"></Button>
+          <Button @click="onConfirmHandler" :variation="'warning'" :title="confirmButtonText" :size="'fixed-width'"></Button>
         </div>
       </div>
     </div>
@@ -50,6 +50,14 @@ export default class ModalConfirmation extends Vue {
 
   @Prop()
   text!: string;
+
+  @Prop({ default: 'Confirm' })
+  confirmButtonText!: string;
+
+  onConfirmHandler() {
+    this.$emit('confirm');
+    this.$modal.hide('modal-confirmation');
+  }
 }
 </script>
 

--- a/src/demos/Modals.vue
+++ b/src/demos/Modals.vue
@@ -246,7 +246,7 @@ components: {
           <td>string</td>
           <td>Confirm</td>
           <td>
-            Callback function when confirmed (only in Modal Confirmation)
+            Confirm button text (only in Modal Confirmation)
           </td>
         </tr>
       </tbody>

--- a/src/demos/Modals.vue
+++ b/src/demos/Modals.vue
@@ -147,6 +147,8 @@ components: {
         :width="400"
         :subTitle="'Delete ‘Streamlabs Pillow’'"
         :text="'Are you sure you want to delete the merch item ‘Streamlabs Pillow’? This action cannot be undone.'"
+        @confirm="() => {}"
+        :confirm-button-text="'Delete'"
       ></ModalComp>
 
       <div class="button-container button-container--left">
@@ -229,6 +231,22 @@ components: {
           <td>
             the note of the bottom only used for
             <code>subscribe</code>
+          </td>
+        </tr>
+        <tr>
+          <td>@confirm</td>
+          <td>Function</td>
+          <td>null</td>
+          <td>
+            Callback function when confirmed (only in Modal Confirmation)
+          </td>
+        </tr>
+        <tr>
+          <td>confirm-button-text</td>
+          <td>string</td>
+          <td>Confirm</td>
+          <td>
+            Callback function when confirmed (only in Modal Confirmation)
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
added `@confirm` and `:confirm-button-text`, also made default button text "Confirm", not "Delete"

```
<ModalConfirmation
        :subTitle="modalsubTitle"
        :text="modalText"
        :width="modalWidth"
        :minWidth="modalMinWidth"
        @confirm="$emit('confirm')"
        :confirm-button-text="confirmButtonText"
      ></ModalConfirmation>
```