### PR TITLE
Add repository field to package.json for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "main": "./dist/beaker.es.js",
   "module": "./dist/beaker.es.js",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/streamlabs/beaker.git"
+  },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
The `v1.0.0-rc.0` publish dry-run (see #572) failed at the final `npm publish` step:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/streamlabs/beaker" from provenance
```

The good news: this confirms the OIDC Trusted Publisher setup on npmjs.com works correctly — auth succeeded and a provenance statement was signed and published to the Sigstore transparency log. The only problem is `package.json` has no `repository` field, which npm's provenance verification requires to cross-check against the GitHub identity asserted by the OIDC token. This adds it.

## Test plan
- [x] `pnpm lint` exits 0
- [x] `pnpm build:publish` exits 0, zero TypeScript errors
- [ ] Re-tag a prerelease (e.g. `v1.0.0-rc.1`) after this merges and confirm the publish workflow completes successfully end-to-end
