### PR TITLE
Fix release workflow to respect master's branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 # Manually-triggered "Release" button — pick a bump type in the Actions tab.
-# Bumps package.json's version, commits, tags, and pushes in one step. The
-# tag push triggers publish.yml (npm) and the master push triggers
-# deploy-pages.yml (GitHub Pages) — both already exist and are untouched.
+# Bumps package.json's version, commits it to a new release/vX.Y.Z branch,
+# and opens a PR into master. master has branch protection requiring all
+# changes go through a PR with a passing "ci" check, so this workflow can't
+# push directly to it — merging the generated PR is what actually lands the
+# bump. tag-release.yml (triggered by that merge) creates the git tag, which
+# in turn triggers publish.yml (npm) and deploy-pages.yml (GitHub Pages).
 on:
   workflow_dispatch:
     inputs:
@@ -18,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -36,10 +40,17 @@ jobs:
           npm version ${{ inputs.bump }} --no-git-tag-version
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Commit, tag, and push
+      - name: Commit to release branch and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "release/v${{ steps.bump.outputs.version }}"
           git commit -am "chore: release v${{ steps.bump.outputs.version }}"
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push --follow-tags
+          git push origin "release/v${{ steps.bump.outputs.version }}"
+          gh pr create \
+            --base master \
+            --head "release/v${{ steps.bump.outputs.version }}" \
+            --title "chore: release v${{ steps.bump.outputs.version }}" \
+            --body "Merging this PR bumps the published version to v${{ steps.bump.outputs.version }}. Once merged, tag-release.yml tags the commit, which triggers the npm publish and GitHub Pages deploy workflows automatically."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,49 @@
+name: Tag Release
+
+# Runs on every push to master. If package.json's version changed compared
+# to the previous commit (i.e. a release.yml PR was just merged), creates
+# and pushes a git tag for that version. This is a tag push only — not a
+# push to master itself — so it isn't blocked by master's branch protection
+# (which only restricts refs/heads/master, not refs/tags/*). That tag push
+# triggers the existing publish.yml (npm).
+on:
+  push:
+    branches: [master]
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for a version change
+        id: check
+        run: |
+          PREV_VERSION=$(git show HEAD^:package.json | jq -r .version 2>/dev/null || echo "")
+          CURR_VERSION=$(jq -r .version package.json)
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$CURR_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and push
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          TAG="v${{ steps.check.outputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Publishing is tag-driven: pushing a git tag matching `v*` triggers `.github/work
 
 `next` will be promoted to `latest` once Vue 3 is stable enough to become the default install.
 
-**Vue 3 (`master`):** releases are cut with a button, not a manual tag push. Go to the repo's **Actions** tab → **Release** workflow → **Run workflow**, pick a bump type (`patch`/`minor`/`major`), and run it. It bumps `package.json`'s version, commits, tags, and pushes to `master` in one step — which triggers `publish.yml` above automatically. The docs site on GitHub Pages also redeploys automatically on every push to `master`, independent of releases.
+**Vue 3 (`master`):** releases are cut with a button, not a manual tag push. Go to the repo's **Actions** tab → **Release** workflow → **Run workflow**, pick a bump type (`patch`/`minor`/`major`), and run it. `master` requires all changes to go through a pull request, so the workflow opens a PR bumping `package.json`'s version rather than pushing to `master` directly — review and merge that PR to actually cut the release. Merging it triggers `.github/workflows/tag-release.yml`, which tags the commit and triggers `publish.yml` above automatically. The docs site on GitHub Pages also redeploys automatically on every push to `master`, independent of releases.
 
 **Vue 2 (`v0.x`):** stays fully manual — bump `package.json`'s version by hand, commit, then `git tag v0.x.y && git push --follow-tags` to trigger `publish.yml`.
 

--- a/backlog/tasks/task-23.1 - Fix-release.yml-PR-based-flow-to-respect-master-branch-protection.md
+++ b/backlog/tasks/task-23.1 - Fix-release.yml-PR-based-flow-to-respect-master-branch-protection.md
@@ -1,0 +1,45 @@
+---
+id: TASK-23.1
+title: 'Fix release.yml: PR-based flow to respect master branch protection'
+status: Done
+assignee: []
+created_date: '2026-07-24 22:58'
+updated_date: '2026-07-24 23:02'
+labels:
+  - ci-cd
+  - bugfix
+dependencies: []
+parent_task_id: TASK-23
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The "Release" button workflow (release.yml) added in TASK-23 fails: it tries to git push a version-bump commit + tag directly to master, but master has branch protection requiring all changes go through a pull request with a passing "ci" status check (required_approving_review_count is 0, but direct pushes are still hard-blocked — confirmed via a real failed run, GH006 "Protected branch update failed", error: "Changes must be made through a pull request"). No bypass list is configured for this rule, and the user chose the PR-based redesign over provisioning a bypass credential (discussed tradeoffs: a dedicated bypass-capable token needs to be created/rotated and only used in this one workflow, vs. no new credential but one extra manual "merge PR" click per release).
+
+Confirmed no tag protection rules or rulesets exist on the repo (only the one classic branch protection rule on master), so pushing a tag directly (not a branch commit) is NOT blocked — only pushes to refs/heads/master itself are blocked.
+
+Redesign:
+1. Modify .github/workflows/release.yml: instead of committing+tagging+pushing directly to master, create a branch (e.g. release/v<version>), commit the version bump there, push that branch, and open a PR into master via `gh pr create` (needs `pull-requests: write` permission added). Do NOT create/push a tag in this workflow anymore.
+2. Add a new workflow (e.g. .github/workflows/tag-release.yml) triggered on push to master: checks whether package.json's version changed vs the previous commit (fetch-depth: 2 diff, same pattern originally considered during TASK-23 planning before the button design was chosen), and if so, creates and pushes just an annotated tag `v<version>` to that already-merged commit. This is a tag push only, not a branch push, so it isn't blocked by the "required pull request" rule.
+3. No changes needed to the existing publish.yml (tag-triggered) or deploy-pages.yml (master-push-triggered) — both continue to work unchanged once the tag lands / the PR merges.
+
+New end-to-end flow: click "Release" → bot opens a PR with the version bump → user reviews and merges it (satisfying branch protection + required ci check) → merge triggers both the new tag-creation workflow (which triggers publish.yml) and the existing deploy-pages.yml, automatically.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 release.yml no longer pushes directly to master; it creates a release branch, commits the version bump there, and opens a PR into master
+- [x] #2 release.yml has pull-requests: write permission for the gh pr create step
+- [x] #3 A new workflow detects a version change on push to master and pushes only a tag (no commit) for that version, triggering the existing publish.yml
+- [x] #4 Existing publish.yml and deploy-pages.yml are unmodified
+- [x] #5 Both workflow YAML files parse successfully
+- [x] #6 README.md's release documentation is updated to describe the new PR-based flow (click Release -> review/merge the generated PR -> publish + deploy happen automatically)
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rewrote release.yml to open a PR (branch release/vX.Y.Z) instead of pushing the version bump directly to master, since master's branch protection hard-blocks direct pushes regardless of permissions. Added pull-requests: write permission and a `gh pr create` step. Added a new tag-release.yml that triggers on push to master (path-filtered to package.json), diffs the version against the previous commit via jq, and — only if it changed — pushes just a tag (not a branch commit) for that version; tag pushes aren't covered by the "required pull request" rule since they're a different ref namespace (refs/tags/* vs refs/heads/master), confirmed via the GitHub API that no tag protection rules or rulesets exist on this repo. That tag continues to trigger the existing, unmodified publish.yml. Updated README's release section to describe the new flow: click Release -> review/merge the generated PR -> publish + Pages deploy happen automatically from the merge. Verified both workflow files parse via js-yaml and sanity-checked the jq version-diff logic locally. Not yet tested end-to-end on GitHub (requires an actual workflow_dispatch run + PR merge) since that can only be verified after this PR merges.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary
The "Release" button (`release.yml`) failed on its first real run — it pushed a version-bump commit + tag directly to `master`, but `master` requires all changes to go through a PR with a passing `ci` check (`GH006: Protected branch update failed`).

- `release.yml` now creates a `release/vX.Y.Z` branch, commits the version bump there, and opens a PR into `master` instead of pushing directly
- New `tag-release.yml` triggers on push to `master`, detects the version change once that PR is merged, and pushes just the tag (not a branch commit — tags aren't covered by the "required pull request" rule) — which still triggers the existing, unmodified `publish.yml`
- `publish.yml` and `deploy-pages.yml` are untouched
- README's release section updated to describe the new flow

## Test plan
- [x] Both workflow YAML files validated with `js-yaml`
- [x] Version-diff `jq` logic sanity-checked locally
- [ ] End-to-end verification (workflow_dispatch run → PR appears → merge → tag created → publish + deploy fire) — can only be done after this PR merges, since it needs to run from `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)