### PR TITLE
Use a PAT for the release tag push so publish.yml actually triggers

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,6 +6,10 @@ name: Tag Release
 # push to master itself — so it isn't blocked by master's branch protection
 # (which only restricts refs/heads/master, not refs/tags/*). That tag push
 # triggers the existing publish.yml (npm).
+#
+# Uses RELEASE_TAG_PAT (not the default GITHUB_TOKEN) to push the tag:
+# GitHub doesn't let GITHUB_TOKEN-authored pushes trigger other workflow
+# runs, which would silently prevent publish.yml from ever firing.
 on:
   push:
     branches: [master]
@@ -22,6 +26,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 2
+          token: ${{ secrets.RELEASE_TAG_PAT }}
 
       - name: Check for a version change
         id: check


### PR DESCRIPTION
## Summary
The v1.0.1 release exposed a gap in `tag-release.yml`: it pushed the tag using the default `GITHUB_TOKEN`, but GitHub doesn't let `GITHUB_TOKEN`-authenticated pushes trigger other workflow runs. The tag landed correctly but `publish.yml` never ran — silently, with no error anywhere. Re-pushing the same tag with real credentials triggered it as expected.

This uses the `RELEASE_TAG_PAT` secret (a fine-grained PAT scoped to just this repo, `Contents: read and write`) for the checkout/push instead, so the tag push behaves like a normal authenticated push and triggers `publish.yml` correctly.

Note: `publish.yml`'s `npm-publish` environment still requires manual reviewer approval before it actually runs — that's a separate, intentional gate and is unaffected by this change.

## Test plan
- [ ] YAML validated with `js-yaml`
- [ ] Next real release: confirm `publish.yml` gets a run created immediately after the tag pushes, without needing a manual re-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)