### PR TITLE
Opt every published component into Vue 3 compat MODE 3

### DIFF
--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -65,6 +65,8 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, useSlots } from 'vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = defineProps<{
   openedTitle?: string;
   closedTitle?: string;

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -26,6 +26,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     variant?: string;

--- a/src/components/BannerDiscord.vue
+++ b/src/components/BannerDiscord.vue
@@ -19,6 +19,8 @@
 <script setup lang="ts">
 import Button from "./../components/Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{ title?: string }>(),
   { title: "Join the Streamlabs OBS Discussion on <span>Discord</span>" }

--- a/src/components/BannerIntroduction.vue
+++ b/src/components/BannerIntroduction.vue
@@ -16,6 +16,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ bgColor?: string }>();
 </script>
 

--- a/src/components/BannerMarketing.vue
+++ b/src/components/BannerMarketing.vue
@@ -63,6 +63,8 @@
 import { ref, watch, nextTick, onMounted, useTemplateRef } from "vue";
 import whatInput from "what-input";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     bgImageNight?: string;

--- a/src/components/BannerSale.vue
+++ b/src/components/BannerSale.vue
@@ -33,6 +33,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     title: string;

--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -74,6 +74,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     bgColor?: string;

--- a/src/components/CSLayoutPicker.vue
+++ b/src/components/CSLayoutPicker.vue
@@ -21,6 +21,8 @@
 import { ref } from "vue";
 import { vOnClickOutside } from "@vueuse/components";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const addLayout = ref(true);
 const chooseLayout = ref(false);
 

--- a/src/components/CallToAction.vue
+++ b/src/components/CallToAction.vue
@@ -59,6 +59,8 @@ import { computed } from 'vue';
 import { useMediaQuery } from '@vueuse/core';
 import Button from './../components/Button.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     bgColor?: string;

--- a/src/components/Callout.vue
+++ b/src/components/Callout.vue
@@ -26,6 +26,8 @@
 import { ref, computed } from "vue";
 import Badge from "./../components/Badge.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     variation?: string;

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = defineProps<{
   label: string;
   id: string;

--- a/src/components/ColorPicker.vue
+++ b/src/components/ColorPicker.vue
@@ -69,7 +69,7 @@
 import { ref, computed, useTemplateRef } from "vue";
 import { ChromePicker, tinycolor } from "vue-color";
 
-defineOptions({ inheritAttrs: false });
+defineOptions({ compatConfig: { MODE: 3 }, inheritAttrs: false });
 
 // tinycolor2 (used internally by vue-color) ships no TypeScript types —
 // this captures only the members this component actually calls.

--- a/src/components/ContentRow.vue
+++ b/src/components/ContentRow.vue
@@ -28,6 +28,8 @@ import { computed } from 'vue';
 import { useMediaQuery } from '@vueuse/core';
 import Button from './../components/Button.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{
     icon?: string;

--- a/src/components/EmptySection.vue
+++ b/src/components/EmptySection.vue
@@ -19,6 +19,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{
     variation?: string;

--- a/src/components/FakeAlert.vue
+++ b/src/components/FakeAlert.vue
@@ -11,6 +11,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{
     alertText?: string;

--- a/src/components/FormGroup.vue
+++ b/src/components/FormGroup.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ helpText?: string; tooltip?: string; title?: string }>();
 </script>
 

--- a/src/components/FormGroupH.vue
+++ b/src/components/FormGroupH.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ helpText?: string; tooltip?: string; title?: string }>();
 </script>
 

--- a/src/components/FormGroupV.vue
+++ b/src/components/FormGroupV.vue
@@ -26,6 +26,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     helpText?: string;

--- a/src/components/Guard.vue
+++ b/src/components/Guard.vue
@@ -20,6 +20,8 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     value?: string;

--- a/src/components/GuardNew.vue
+++ b/src/components/GuardNew.vue
@@ -25,6 +25,8 @@
 import { ref } from "vue";
 import TextInput from "./TextInput.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{ value?: string; placeholder?: string }>(),
   { placeholder: "Click to show" }

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -65,5 +65,7 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ msg?: string }>();
 </script>

--- a/src/components/ImagePicker.vue
+++ b/src/components/ImagePicker.vue
@@ -43,6 +43,8 @@
 import { ref, useTemplateRef } from "vue";
 import Button from "./../components/Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const emit = defineEmits<{ upload: [data: File] }>();
 
 const fileInput = useTemplateRef<HTMLInputElement>("fileInput");

--- a/src/components/ImagePickerInput.vue
+++ b/src/components/ImagePickerInput.vue
@@ -25,6 +25,8 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted } from 'vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface IOption {
   value: string;
   title: string;

--- a/src/components/ItemGrid.vue
+++ b/src/components/ItemGrid.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ items?: object[] }>();
 </script>
 

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -20,6 +20,8 @@
 import { ref, onMounted } from "vue";
 import Spinner from "./../components/Spinner.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     loadingStrs?: string[] | string;

--- a/src/components/MediaPicker.vue
+++ b/src/components/MediaPicker.vue
@@ -105,6 +105,8 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, useTemplateRef } from 'vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 // vue-focus mixin removed — v-focus directive is registered globally in main.ts
 
 type MediaControlEmit = 'link-media' | 'preview-media' | 'remove-media' | 'select-media';

--- a/src/components/ModalBasic.vue
+++ b/src/components/ModalBasic.vue
@@ -42,6 +42,8 @@
 import { VueFinalModal } from 'vue-final-modal';
 import Button from './../components/Button.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 withDefaults(

--- a/src/components/ModalComp.vue
+++ b/src/components/ModalComp.vue
@@ -93,7 +93,7 @@
 </template>
 
 <script setup lang="ts">
-defineOptions({ inheritAttrs: false });
+defineOptions({ compatConfig: { MODE: 3 }, inheritAttrs: false });
 
 import ModalBasic from './../components/ModalBasic.vue';
 import ModalSubscribe from './../components/ModalSubscribe.vue';

--- a/src/components/ModalConfirmation.vue
+++ b/src/components/ModalConfirmation.vue
@@ -32,6 +32,8 @@
 import { VueFinalModal } from "vue-final-modal";
 import Button from "./../components/Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 withDefaults(

--- a/src/components/ModalPrime.vue
+++ b/src/components/ModalPrime.vue
@@ -18,6 +18,8 @@
 import { VueFinalModal } from "vue-final-modal";
 import WelcomePrime from "./../components/WelcomePrime.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 withDefaults(

--- a/src/components/ModalPrimeIntro.vue
+++ b/src/components/ModalPrimeIntro.vue
@@ -19,6 +19,8 @@
 import { VueFinalModal } from "vue-final-modal";
 import PrimeIntro from "./PrimeIntro.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 withDefaults(

--- a/src/components/ModalRedirect.vue
+++ b/src/components/ModalRedirect.vue
@@ -21,6 +21,8 @@
 import { VueFinalModal } from "vue-final-modal";
 import Spinner from "./../components/Spinner.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 withDefaults(

--- a/src/components/ModalSubscribe.vue
+++ b/src/components/ModalSubscribe.vue
@@ -60,6 +60,8 @@ import { VueFinalModal } from "vue-final-modal";
 import Button from "./../components/Button.vue";
 import Badge from "./../components/Badge.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 withDefaults(

--- a/src/components/NavCallToAction.vue
+++ b/src/components/NavCallToAction.vue
@@ -23,6 +23,8 @@
 import { computed } from "vue";
 import Button from "./../components/Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     bgColor?: string;

--- a/src/components/NewFeatureOverlay.vue
+++ b/src/components/NewFeatureOverlay.vue
@@ -58,6 +58,8 @@ import { VueFinalModal } from "vue-final-modal";
 import { useMediaQuery } from "@vueuse/core";
 import Button from "./../components/Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const show = defineModel<boolean>({ default: false });
 
 const props = withDefaults(

--- a/src/components/Notice.vue
+++ b/src/components/Notice.vue
@@ -21,6 +21,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     variation?: string;

--- a/src/components/Onboarding.vue
+++ b/src/components/Onboarding.vue
@@ -72,6 +72,8 @@
 import { computed } from "vue";
 import Button from "./../components/Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface IStep { name?: string; complete: boolean }
 
 const props = withDefaults(

--- a/src/components/OnboardingStep.vue
+++ b/src/components/OnboardingStep.vue
@@ -13,6 +13,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ title?: string; desc?: string }>();
 </script>
 

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -27,6 +27,8 @@
 import { ref, computed, onMounted, useTemplateRef } from "vue";
 import Paginate from "vuejs-paginate-next";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     nightBg?: boolean;

--- a/src/components/PaneDropdown.vue
+++ b/src/components/PaneDropdown.vue
@@ -52,6 +52,8 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount, useTemplateRef } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     dropdownIcon?: boolean;

--- a/src/components/PrimeIntro.vue
+++ b/src/components/PrimeIntro.vue
@@ -55,6 +55,8 @@
 <script setup lang="ts">
 import SButton from './../components/Button.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(defineProps<{ primeButtonText?: string }>(), {
   primeButtonText: 'Join Prime',
 });

--- a/src/components/PrimeSection.vue
+++ b/src/components/PrimeSection.vue
@@ -27,6 +27,8 @@ import Badge from "./Badge.vue";
 import Button from "./Button.vue";
 import EmptySection from "./EmptySection.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{ subtitle?: string; href?: string }>();
 const emit = defineEmits<{ click: [] }>();
 </script>

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -7,6 +7,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = defineProps<{ progressComplete?: number }>();
 const getProgress = computed(() => `width:${props.progressComplete}%`);
 </script>

--- a/src/components/Radio.vue
+++ b/src/components/Radio.vue
@@ -14,6 +14,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 defineProps<{
   label: string;
   id: string;

--- a/src/components/SSProSimulator.vue
+++ b/src/components/SSProSimulator.vue
@@ -35,6 +35,8 @@
 import { ref, onMounted, onBeforeUnmount } from "vue";
 import UrlBar from "./../components/UrlBar.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{ username?: string; icon?: string; domain?: string }>(),
   {

--- a/src/components/ScrollNav.vue
+++ b/src/components/ScrollNav.vue
@@ -43,6 +43,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, useTemplateRef } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface INavItem {
   name: string;
   value: string;

--- a/src/components/Selector.vue
+++ b/src/components/Selector.vue
@@ -16,6 +16,8 @@
 import { computed } from "vue";
 import Multiselect from "vue-multiselect";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = defineProps<{
   width?: string;
   multiple?: boolean;

--- a/src/components/SiteSearch.vue
+++ b/src/components/SiteSearch.vue
@@ -87,6 +87,8 @@
 import { ref, computed, watch, onMounted, useTemplateRef } from "vue";
 import Fuse, { type FuseResult } from "fuse.js";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface SearchEntry {
   name: string;
   title: string;

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -28,6 +28,8 @@ import { ref, watch, onMounted, useTemplateRef } from "vue";
 import VueSliderComponent from "vue-slider-component";
 import "vue-slider-component/theme/default.css";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     width?: number | string;

--- a/src/components/SliderTwo.vue
+++ b/src/components/SliderTwo.vue
@@ -51,6 +51,8 @@ import {
   useTemplateRef,
 } from 'vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 type SliderValue = number | string;
 
 const props = withDefaults(

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -140,6 +140,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{ size?: string; swap?: boolean }>(),
   { size: "small", swap: false }

--- a/src/components/StatusSwitch.vue
+++ b/src/components/StatusSwitch.vue
@@ -17,6 +17,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{ label?: string; size?: string; modelValue?: boolean }>(),
   { modelValue: false },

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -22,6 +22,8 @@
 <script setup lang="ts">
 import Badge from './../components/Badge.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(
   defineProps<{
     title?: string;

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -67,6 +67,8 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount, useTemplateRef } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface ITab {
   name: string;
   value: string;

--- a/src/components/TabsNew.vue
+++ b/src/components/TabsNew.vue
@@ -85,6 +85,8 @@ import { cloneDeep } from 'lodash-es';
 import whatInput from 'what-input';
 import PaneDropdown from './PaneDropdown.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface ITab {
   name: string;
   value: string;

--- a/src/components/TaggingInput.vue
+++ b/src/components/TaggingInput.vue
@@ -44,6 +44,8 @@ import Button from './Button.vue';
 import { validate } from 'vee-validate';
 import '../composables/useValidation';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     name: string;

--- a/src/components/TextArea.vue
+++ b/src/components/TextArea.vue
@@ -53,7 +53,7 @@
 import { computed, nextTick, onMounted, onUpdated, ref, useAttrs, useTemplateRef } from "vue";
 import { omit } from "lodash-es";
 
-defineOptions({ inheritAttrs: false });
+defineOptions({ compatConfig: { MODE: 3 }, inheritAttrs: false });
 
 const model = defineModel<string>({ default: "" });
 

--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -71,7 +71,7 @@
 import { computed, useAttrs, useTemplateRef } from 'vue';
 import { omit, isNil } from 'lodash-es';
 
-defineOptions({ inheritAttrs: false });
+defineOptions({ compatConfig: { MODE: 3 }, inheritAttrs: false });
 
 const model = defineModel<string | number>({ default: '' });
 

--- a/src/components/Toggle.vue
+++ b/src/components/Toggle.vue
@@ -18,6 +18,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = defineProps<{
   values: Record<string | number, string>;
   modelValue: string;

--- a/src/components/TooltipNotice.vue
+++ b/src/components/TooltipNotice.vue
@@ -31,6 +31,8 @@
 import { computed } from "vue";
 import Button from "./Button.vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     title: string;

--- a/src/components/UrlBar.vue
+++ b/src/components/UrlBar.vue
@@ -10,6 +10,8 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(defineProps<{ domain?: string }>(), {
   domain: "https://awkwardraccoon.com",
 });

--- a/src/components/VariableMenu.vue
+++ b/src/components/VariableMenu.vue
@@ -51,6 +51,8 @@
 import { ref, computed, watch, onMounted, useTemplateRef } from 'vue';
 import Fuse, { type FuseResult } from 'fuse.js';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 interface VariableEntry {
   variable: string;
   description?: string;

--- a/src/components/VirtualItem.vue
+++ b/src/components/VirtualItem.vue
@@ -32,6 +32,8 @@
 <script setup lang="ts">
 import { computed, useAttrs } from "vue";
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 const props = withDefaults(
   defineProps<{
     name?: string;

--- a/src/components/WelcomePrime.vue
+++ b/src/components/WelcomePrime.vue
@@ -43,6 +43,8 @@
 import { ref, computed, onMounted, useSlots } from 'vue';
 import Button from './../components/Button.vue';
 
+defineOptions({ compatConfig: { MODE: 3 } });
+
 withDefaults(defineProps<{ primeButtonText?: string }>(), {
   primeButtonText: 'Continue',
 });


### PR DESCRIPTION
compatConfig is read off each component's own definition object rather than inherited via extends/mixins, so it has to be set per component rather than once globally. Adds defineOptions({ compatConfig: { MODE: 3 } }) (merged into existing defineOptions calls where present) to all 64 components exported from system.ts, so they behave as full Vue 3 even when consumed by an app still running @vue/compat in MODE 2.