### PR TITLE
Use RELEASE_TAG_PAT to open release PRs so CI runs without manual approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          token: ${{ secrets.RELEASE_TAG_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -40,9 +42,14 @@ jobs:
           npm version ${{ inputs.bump }} --no-git-tag-version
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
+      # Uses RELEASE_TAG_PAT (not the default GITHUB_TOKEN) for the checkout, push, and
+      # PR creation: GitHub now requires manual approval before running workflows (like
+      # the "ci" check master's branch protection requires) on PRs authored by
+      # github-actions[bot], even for same-repo branches. Authoring the PR as the PAT's
+      # user instead avoids that approval step so CI runs immediately.
       - name: Commit to release branch and open PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TAG_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- release.yml opened its release PR using the default `GITHUB_TOKEN`, which authors the PR as `github-actions[bot]`
- GitHub now requires manual approval before running workflows (including the `ci` check master's branch protection requires) on PRs authored by that bot, even for same-repo branches — this left PR #583 (`chore: release v1.0.2`) stuck with CI in `action_required` until manually approved
- Switches the checkout, push, and `gh pr create` call to use `RELEASE_TAG_PAT` instead, so the PR is attributed to a real user and CI runs immediately — same fix pattern already applied to `tag-release.yml` for the equivalent `GITHUB_TOKEN` limitation

## Test plan
- [ ] Trigger the "Release" workflow (patch bump) and confirm the resulting PR's `ci` check starts automatically without needing manual approval in the Actions tab
- [ ] Merge that PR and confirm `tag-release.yml` fires and pushes the tag