### PR TITLE
Bundle vue-color's CSS into the published library build

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -8,6 +8,13 @@
 // teleports overlay/content outside the component tree.
 import './styles/components/Modals.less';
 
+// vue-color ships its own CSS separately from its JS (gradient backgrounds, saturation/hue
+// slider handles, etc.) — ColorPicker.vue doesn't import it itself, and src/main.ts (the
+// local demo app) importing it only masked the gap here, since consumers of dist/beaker.es.js
+// never pull in anything main.ts imports. Without this, ColorPicker renders unstyled in any
+// consuming app.
+import 'vue-color/style.css';
+
 export { default as Accordion } from './components/Accordion.vue';
 export { default as Badge } from './components/Badge.vue';
 export { default as BannerDiscord } from './components/BannerDiscord.vue';


### PR DESCRIPTION
## Summary
- `ColorPicker.vue` imports vue-color's JS (`ChromePicker`, `tinycolor`) but vue-color ships its CSS as a separate entry (`vue-color/style.css`) — the component renders unstyled without it (no gradients, no saturation/hue slider backgrounds, no draggable handle)
- `src/main.ts` (the local demo app) already imports `vue-color/style.css`, which masked this: that only affects the demo site, since consumers of `dist/beaker.es.js` never pull in anything `main.ts` imports
- `src/system.ts` is the actual published library entry (built via `vite-publish.config.js` into `dist/style.css`), and it had no such import — so any consuming app (e.g. streamlabs.com) got an unstyled ColorPicker
- Adds `import 'vue-color/style.css';` to `src/system.ts`, next to the existing modal-CSS import that follows the same pattern

## Test plan
- [x] `npm run build:publish` — confirmed `dist/style.css` grew from 194.07 kB to 215.57 kB and now contains all `.vc-*` classes (`.vc-chrome-picker`, `.vc-hue-slider`, `.vc-hsv-sliders`, etc.) that were previously missing
- [x] `npm run lint` and `npm run build` both pass
- [ ] Verify ColorPicker renders correctly in a consuming app after this is published