### PR TITLE
chore: release v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlabs-beaker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "./dist/beaker.es.js",
   "module": "./dist/beaker.es.js",
   "license": "MIT",


### PR DESCRIPTION
Merging this PR bumps the published version to v1.0.3. Once merged, tag-release.yml tags the commit, which triggers the npm publish and GitHub Pages deploy workflows automatically.